### PR TITLE
Update ClickHouse image version & fix test

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,8 +26,8 @@ dependencies {
     testImplementation("org.junit.jupiter", "junit-jupiter-api", "5.8.2")
     testImplementation("org.junit.jupiter", "junit-jupiter-engine", "5.8.2")
 
-    testImplementation("org.testcontainers", "testcontainers", "1.17.1")
-    testImplementation("org.testcontainers", "clickhouse", "1.17.1")
+    testImplementation("org.testcontainers", "testcontainers", "1.17.3")
+    testImplementation("org.testcontainers", "clickhouse", "1.17.3")
 }
 
 tasks.withType<JavaCompile> {

--- a/src/test/kotlin/tanvd/aorm/implementation/table/EngineClickhouseTest.kt
+++ b/src/test/kotlin/tanvd/aorm/implementation/table/EngineClickhouseTest.kt
@@ -71,7 +71,7 @@ object MergeTreeTable : Table("MergeTreeTable") {
 
 object CustomMergeTreeTable : Table("CustomMergeTreeTable") {
     val date = date("date")
-    val id = int64("id").default { 1L }
+    val id = uint64("id").default { 1L }
 
     override val engine: Engine.MergeTree = Engine.MergeTree(date, listOf(id), 8192).partitionBy(date).sampleBy(id).orderBy(id)
 }

--- a/src/test/kotlin/tanvd/aorm/utils/AormTestBase.kt
+++ b/src/test/kotlin/tanvd/aorm/utils/AormTestBase.kt
@@ -14,8 +14,7 @@ abstract class AormTestBase {
     companion object {
         const val testInsertWorkerDelayMs = 2000L
 
-        // consider using 'clickhouse/clickhouse-server' after testcontainers version update
-        val serverContainer = ClickHouseContainer("yandex/clickhouse-server:21.1-alpine").apply {
+        val serverContainer = ClickHouseContainer("clickhouse/clickhouse-server:22.3.8.39-alpine").apply {
             start()
             // we need to disable query parser stack limitation for tests, so we add line "<max_parser_depth>0</max_parser_depth>" to the config:
             execInContainer("sed", "-i", "/^.*\\<max_memory_usage\\>.*/a \\<max_parser_depth\\>0\\<\\/max_parser_depth\\>", "/etc/clickhouse-server/users.xml")


### PR DESCRIPTION
Updated container image version to the latest ClickHouse LTS release at the moment (22.3.8.39).

Had to change column type in test CustomMergeTreeTable to uint, since `sampleBy` now only works with unsigned int.

```
Code: 59. DB::Exception: Invalid sampling column type in storage parameters: Int64. Must be one unsigned integer type. (ILLEGAL_TYPE_OF_COLUMN_FOR_FILTER) (version 22.3.8.39 (official build))
```